### PR TITLE
Debian support, added switch for control over restarts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 # Python virtual env for Molecule testing
 molecule-venv/
+.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,0 @@
-{
-    "restructuredtext.confPath": "",
-    "cSpell.words": [
-        "getent",
-        "isdir",
-        "islnk"
-    ]
-}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ needed.
 | kafka_scala_version                | 2.13                                 |
 | kafka_root_dir                     | /opt                                 |
 | kafka_dir                          | {{ kafka_root_dir }}/kafka           |
+| kafka_start                        | yes                                  |
+| kafka_restart                      | yes                                  |
 | kafka_broker_id                    | 0                                    |
 | kafka_listener_protocol            | PLAINTEXT                            |
 | kafka_listener_hostname            | localhost                            |

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ can be elastically scaled with no downtime.
 
 ## Requirements
 
-- Platform: RHEL / CentOS 6 and 7
-- Java: Java 8
+- Platform: RHEL / CentOS 6 and 7 / Debian or Ubuntu
+- Java: Java 8 / 11
 - Apache ZooKeeper
 
 The below Apache ZooKeeper role from Ansible Galaxy can be used if one is

--- a/README.md
+++ b/README.md
@@ -25,27 +25,28 @@ needed.
 
 ## Role Variables
 
-| Variable                           | Default                    |
-| ---------------------------------- | -------------------------- |
-| kafka_version                      | 2.7.0                      |
-| kafka_scala_version                | 2.13                       |
-| kafka_root_dir                     | /opt                       |
-| kafka_dir                          | {{ kafka_root_dir }}/kafka |
-| kafka_broker_id                    | 0                          |
-| kafka_listener_protocol            | PLAINTEXT                  |
-| kafka_listener_hostname            | localhost                  |
-| kafka_listener_port                | 9092                       |
-| kafka_num_network_threads          | 3                          |
-| kafka_log_dirs                     | /var/lib/kafka-logs        |
-| kafka_num_partitions               | 1                          |
-| kafka_log_retention_hours          | 168                        |
-| kafka_auto_create_topics_enable    | true                       |
-| kafka_delete_topic_enable          | true                       |
-| kafka_default_replication_factor   | 1                          |
-| kafka_zookeeper_connect            | localhost:2181             |
-| kafka_zookeeper_connection_timeout | 6000                       |
-| kafka_bootstrap_servers            | localhost:9092             |
-| kafka_consumer_group_id            | kafka-consumer-group       |
+| Variable                           | Default                              |
+| ---------------------------------- | ------------------------------------ |
+| kafka_download_base_url            | http://www-eu.apache.org/dist/kafka  |
+| kafka_version                      | 2.7.0                                |
+| kafka_scala_version                | 2.13                                 |
+| kafka_root_dir                     | /opt                                 |
+| kafka_dir                          | {{ kafka_root_dir }}/kafka           |
+| kafka_broker_id                    | 0                                    |
+| kafka_listener_protocol            | PLAINTEXT                            |
+| kafka_listener_hostname            | localhost                            |
+| kafka_listener_port                | 9092                                 |
+| kafka_num_network_threads          | 3                                    |
+| kafka_log_dirs                     | /var/lib/kafka-logs                  |
+| kafka_num_partitions               | 1                                    |
+| kafka_log_retention_hours          | 168                                  |
+| kafka_auto_create_topics_enable    | true                                 |
+| kafka_delete_topic_enable          | true                                 |
+| kafka_default_replication_factor   | 1                                    |
+| kafka_zookeeper_connect            | localhost:2181                       |
+| kafka_zookeeper_connection_timeout | 6000                                 |
+| kafka_bootstrap_servers            | localhost:9092                       |
+| kafka_consumer_group_id            | kafka-consumer-group                 |
 
 ## Starting and Stopping Kafka services using systemd
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,5 +1,7 @@
 ---
 # The Apache Kafka version to be downloaded and installed
+# kafka_download_base_url should be set to https://archive.apache.org/dist/kafka/ for older versions thant current
+kafka_download_base_url: http://www-eu.apache.org/dist/kafka
 kafka_version: 2.7.0
 kafka_scala_version: 2.13
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -12,6 +12,11 @@ kafka_group: kafka
 kafka_root_dir: /opt
 kafka_dir: "{{ kafka_root_dir }}/kafka"
 
+# Start kafka after installation
+kafka_start: yes
+# Restart kafka on configuration change
+kafka_restart: yes
+
 ############################# Server #############################
 
 # The id of the broker. This must be set to a unique integer for each broker.

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 # The Apache Kafka version to be downloaded and installed
-# kafka_download_base_url should be set to https://archive.apache.org/dist/kafka/ for older versions thant current
+# kafka_download_base_url should be set to https://archive.apache.org/dist/kafka/ for older versions than the current
 kafka_download_base_url: http://www-eu.apache.org/dist/kafka
 kafka_version: 2.7.0
 kafka_scala_version: 2.13

--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -6,9 +6,11 @@
   service:
     name: kafka
     state: restarted
+  when: kafka_restart
 
 - name: Restart kafka systemd
   systemd:
     name: kafka
     state: restarted
     daemon_reload: yes
+  when: kafka_restart

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,4 +1,12 @@
 ---
+- name: Load OS-specific variables
+  include_vars: "{{ item }}"
+  with_first_found:
+    - ../vars/{{ ansible_os_family }}.yml
+    - ../vars/{{ ansible_distribution_release }}.yml
+    - ../vars/empty.yml
+  tags: 
+    - always
 
 - name: Create kafka group
   group:
@@ -174,13 +182,13 @@
   tags:
     - kafka_service
 
-- name: Template kafka systemd service file to /usr/lib/systemd/system/kafka.service
+- name: Template kafka systemd service
   template:
     src: kafka.service.j2
-    dest: /usr/lib/systemd/system/kafka.service
+    dest: "{{ kafka_unit_path }}"
   notify:
     - Restart kafka systemd
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version > '6'
+  when: ansible_os_family == "RedHat" and ansible_distribution_major_version > '6' or ansible_os_family == "Debian"
   tags:
     - kafka_service
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -192,24 +192,12 @@
   tags:
     - kafka_service
 
-- name: Populate service facts
-  ansible.builtin.service_facts:
-  tags:
-    - kafka_service
-
-- name: Debug service state
-  debug:
-    msg:
-      "kafka service state": "{{ ansible_facts.services['kafka.service'].state }}"
-  tags:
-    - kafka_service
-
 - name: Install and start the kafka service
   service:
     name: kafka
     state: started
     enabled: yes
-  when: kafka_start and ansible_facts.services['kafka.service'].state in ['stopped', 'inactive']  
+  when: kafka_start
   tags:
     - kafka_service
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -31,7 +31,7 @@
 
 - name: Download Apache Kafka
   get_url:
-    url: http://www-eu.apache.org/dist/kafka/{{ kafka_version }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz
+    url: "{{ kafka_download_base_url }}/{{ kafka_version }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz"
     dest: /tmp
   when: not dir.stat.exists
   tags:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -196,7 +196,6 @@
   service:
     name: kafka
     state: started
-    enabled: yes
   tags:
     - kafka_service
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -170,6 +170,18 @@
   tags:
     - kafka_config
 
+- name: Populate service facts
+  ansible.builtin.service_facts:
+  tags:
+    - kafka_service
+
+- name: Debug service state
+  debug:
+    msg:
+      "kafka service state": "{{ ansible_facts.services['kafka.service'].state }}"
+  tags:
+    - kafka_service
+
 - name: Template Kafka init.d service file
   template:
     src: kafka.initd.j2
@@ -196,6 +208,7 @@
   service:
     name: kafka
     state: started
+  when: kafka_start and ansible_facts.services['kafka.service'].state in ['stopped', 'inactive']  
   tags:
     - kafka_service
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -208,6 +208,7 @@
   service:
     name: kafka
     state: started
+    enabled: yes
   when: kafka_start and ansible_facts.services['kafka.service'].state in ['stopped', 'inactive']  
   tags:
     - kafka_service

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -170,18 +170,6 @@
   tags:
     - kafka_config
 
-- name: Populate service facts
-  ansible.builtin.service_facts:
-  tags:
-    - kafka_service
-
-- name: Debug service state
-  debug:
-    msg:
-      "kafka service state": "{{ ansible_facts.services['kafka.service'].state }}"
-  tags:
-    - kafka_service
-
 - name: Template Kafka init.d service file
   template:
     src: kafka.initd.j2
@@ -201,6 +189,18 @@
   notify:
     - Restart kafka systemd
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version > '6' or ansible_os_family == "Debian"
+  tags:
+    - kafka_service
+
+- name: Populate service facts
+  ansible.builtin.service_facts:
+  tags:
+    - kafka_service
+
+- name: Debug service state
+  debug:
+    msg:
+      "kafka service state": "{{ ansible_facts.services['kafka.service'].state }}"
   tags:
     - kafka_service
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,2 @@
+---
+kafka_unit_path: /etc/systemd/system/kafka.service

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,2 +1,2 @@
 ---
-kafka_unit_path: /etc/systemd/system/kafka.service
+kafka_unit_path: /lib/systemd/system/kafka.service

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,2 @@
+---
+kafka_unit_path: /usr/lib/systemd/system/kafka.service


### PR DESCRIPTION
Greetings,

This follows https://github.com/sleighzy/ansible-zookeeper/pull/13
In this repository, I had the same need for a switch variable to prevent the cluster from starting/restarting upon changes/first-install.
Since I went for Kafka 2.4.0 first (currently 2.7.0), I've added a variable to help switch from the current repository to archive.

Thanks for your review!