### PR TITLE
Update Molecule tests to run on all supported platforms

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,2 +1,7 @@
 exclude_paths:
   - ./molecule-venv/
+  - ./tests/roles/
+
+skip_list:
+  - '106'  # Role name does not match ``^[a-z][a-z0-9_]+$`` pattern
+  

--- a/.github/workflows/ansible-lint.yaml
+++ b/.github/workflows/ansible-lint.yaml
@@ -1,0 +1,28 @@
+---
+name: Ansible Lint
+
+#
+# Documentation:
+# https://github.com/ansible/ansible-lint-action
+#
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Ansible Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Lint Ansible Role
+        uses: ansible/ansible-lint-action@master
+        with:
+          targets: ''

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,0 +1,32 @@
+---
+name: Lint Code Base
+
+#
+# Documentation:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+#
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Linter
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v3
+        env:
+          DEFAULT_BRANCH: master
+          FILTER_REGEX_EXCLUDE: .*(tests/|Dockerfile.j2).*
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LINTER_RULES_PATH: /
+          MARKDOWN_CONFIG_FILE: .markdownlint.json

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -1,0 +1,39 @@
+name: Molecule
+
+on:
+  push:
+    branches:
+      - master
+      - release/v*
+  pull_request:
+    branches:
+      - master
+
+defaults:
+  run:
+    working-directory: 'sleighzy.kafka'
+
+jobs:
+  molecule:
+    name: Molecule
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the codebase.
+        uses: actions/checkout@v2
+        with:
+          path: 'sleighzy.kafka'
+
+      - name: Set up Python 3.
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install test dependencies.
+        run: pip3 install ansible ansible-lint yamllint docker molecule[docker,lint]
+
+      - name: Run Molecule tests.
+        run: molecule test
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,9 +1,13 @@
 {
+  "line-length": {
+    "code_blocks": false,
+    "tables": false
+  },
   "list-marker-space": {
     "ol_single": 2,
     "ol_multi": 2
   },
-  "line-length": {
-    "code_blocks": false
+  "no-inline-html": {
+    "allowed_elements": ["br"]
   }
 }

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -2,8 +2,13 @@
 # Based on ansible-lint config
 extends: default
 
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+
 ignore: |
   molecule-venv/
+  tests/roles/
 
 rules:
   braces:

--- a/README.md
+++ b/README.md
@@ -1,54 +1,63 @@
 # Apache Kafka
 
-[![Build Status](https://travis-ci.org/sleighzy/ansible-kafka.svg?branch=master)](https://travis-ci.org/sleighzy/ansible-kafka)
+[![Build Status]](https://travis-ci.org/sleighzy/ansible-kafka)
+![Lint Code Base] ![Ansible Lint] ![Molecule]
 
-Ansible role to install and configure [Apache Kafka][1] 2.0.0 on RHEL / CentOS 6
-and 7.
+Ansible role to install and configure [Apache Kafka] 2.7.0
 
-[Apache Kafka](http://kafka.apache.org/) is a message bus using
-publish-subscribe topics. Other components and products can consume these
-messages by subscribing to these topics. Kafka is extremely fast, handling
-megabytes of reads and writes per second from thousands of clients. Messages are
-persisted and replicated to prevent data loss. Data streams are partitioned and
-can be elastically scaled with no downtime.
+[Apache Kafka] is a distributed event streaming platform using publish-subscribe
+topics. Applications and streaming components can produce and consume messages
+by subscribing to these topics. Kafka is extremely fast, handling megabytes of
+reads and writes per second from thousands of clients. Messages are persisted
+and replicated to prevent data loss. Data streams are partitioned and can be
+elastically scaled with no downtime.
+
+## Supported Platforms
+
+- RedHat 6
+- RedHat 7
+- RedHat 8
+- Debian 10.x
+- Ubuntu 18.04.x
 
 ## Requirements
 
-- Platform: RHEL / CentOS 6 and 7 / Debian or Ubuntu
-- Java: Java 8 / 11
-- Apache ZooKeeper
+- [Apache ZooKeeper]
+- Java 8 / 11
 
 The below Apache ZooKeeper role from Ansible Galaxy can be used if one is
 needed.
 
-`$ ansible-galaxy install sleighzy.zookeeper`
+```sh
+ansible-galaxy install sleighzy.zookeeper
+```
 
 ## Role Variables
 
-| Variable                           | Default                              |
-| ---------------------------------- | ------------------------------------ |
-| kafka_download_base_url            | http://www-eu.apache.org/dist/kafka  |
-| kafka_version                      | 2.7.0                                |
-| kafka_scala_version                | 2.13                                 |
-| kafka_root_dir                     | /opt                                 |
-| kafka_dir                          | {{ kafka_root_dir }}/kafka           |
-| kafka_start                        | yes                                  |
-| kafka_restart                      | yes                                  |
-| kafka_broker_id                    | 0                                    |
-| kafka_listener_protocol            | PLAINTEXT                            |
-| kafka_listener_hostname            | localhost                            |
-| kafka_listener_port                | 9092                                 |
-| kafka_num_network_threads          | 3                                    |
-| kafka_log_dirs                     | /var/lib/kafka-logs                  |
-| kafka_num_partitions               | 1                                    |
-| kafka_log_retention_hours          | 168                                  |
-| kafka_auto_create_topics_enable    | true                                 |
-| kafka_delete_topic_enable          | true                                 |
-| kafka_default_replication_factor   | 1                                    |
-| kafka_zookeeper_connect            | localhost:2181                       |
-| kafka_zookeeper_connection_timeout | 6000                                 |
-| kafka_bootstrap_servers            | localhost:9092                       |
-| kafka_consumer_group_id            | kafka-consumer-group                 |
+| Variable                           | Default                               |
+| ---------------------------------- | ------------------------------------- |
+| kafka_download_base_url            | <http://www-eu.apache.org/dist/kafka> |
+| kafka_version                      | 2.7.0                                 |
+| kafka_scala_version                | 2.13                                  |
+| kafka_root_dir                     | /opt                                  |
+| kafka_dir                          | {{ kafka_root_dir }}/kafka            |
+| kafka_start                        | yes                                   |
+| kafka_restart                      | yes                                   |
+| kafka_broker_id                    | 0                                     |
+| kafka_listener_protocol            | PLAINTEXT                             |
+| kafka_listener_hostname            | localhost                             |
+| kafka_listener_port                | 9092                                  |
+| kafka_num_network_threads          | 3                                     |
+| kafka_log_dirs                     | /var/lib/kafka-logs                   |
+| kafka_num_partitions               | 1                                     |
+| kafka_log_retention_hours          | 168                                   |
+| kafka_auto_create_topics_enable    | true                                  |
+| kafka_delete_topic_enable          | true                                  |
+| kafka_default_replication_factor   | 1                                     |
+| kafka_zookeeper_connect            | localhost:2181                        |
+| kafka_zookeeper_connection_timeout | 6000                                  |
+| kafka_bootstrap_servers            | localhost:9092                        |
+| kafka_consumer_group_id            | kafka-consumer-group                  |
 
 ## Starting and Stopping Kafka services using systemd
 
@@ -81,16 +90,12 @@ needed.
 
 ### Directories and Files
 
-<!-- markdownlint-disable MD013 -->
-
 | Directory / File                                             |                                         |
 | ------------------------------------------------------------ | --------------------------------------- |
 | Kafka installation directory (symlink to installed version)  | `/opt/kafka`                            |
 | Kafka configuration directory (symlink to /opt/kafka/config) | `/etc/kafka`                            |
 | Directory to store data files                                | `/var/lib/kafka/logs`                   |
 | Kafka service                                                | `/usr/lib/systemd/system/kafka.service` |
-
-<!-- markdownlint-enable MD013 -->
 
 ## Example Playbook
 
@@ -105,8 +110,7 @@ Add the below to a playbook to run those role against hosts belonging to the
 
 ## Linting
 
-Linting should be done using
-[ansible-lint](https://docs.ansible.com/ansible-lint/)
+Linting should be done using [ansible-lint].
 
 ```sh
 pip3 install ansible-lint --user
@@ -114,13 +118,14 @@ pip3 install ansible-lint --user
 
 ## Testing
 
-This module uses [Molecule](https://molecule.readthedocs.io/en/stable/) as a
-testing framework.
+This module uses the [Ansible Molecule] testing framework. This test suite
+creates a Kafka and ZooKeeper cluster consisting of three nodes running within
+Docker containers. Each container runs a different OS to test the supported
+platforms for this Ansible role.
 
-As per the
-[Molecule Installation guide](https://molecule.readthedocs.io/en/stable/installation.html)
-this should be done using a virtual environment. The commands below will create
-a Python virtual environment and install Molecule including the Docker driver.
+As per the [Molecule Installation guide] this should be done using a virtual
+environment. The commands below will create a Python virtual environment and
+install Molecule including the Docker driver.
 
 ```sh
 $ python3 -m venv molecule-venv
@@ -153,7 +158,7 @@ molecule converge
 molecule verify
 ```
 
-Tear down Molecule tests and Docker container.
+Tear down Molecule tests and Docker containers.
 
 ```sh
 molecule destroy
@@ -161,4 +166,18 @@ molecule destroy
 
 ## License
 
-MIT
+[![MIT license]](https://lbesson.mit-license.org/)
+
+[ansible lint]:
+  https://github.com/sleighzy/ansible-kafka/workflows/Ansible%20Lint/badge.svg
+[ansible-lint]: https://docs.ansible.com/ansible-lint/
+[apache kafka]: http://kafka.apache.org/
+[apache zookeeper]: https://zookeeper.apache.org/
+[build status]: https://travis-ci.org/sleighzy/ansible-kafka.svg?branch=master
+[lint code base]:
+  https://github.com/sleighzy/ansible-kafka/workflows/Lint%20Code%20Base/badge.svg
+[molecule]:
+  https://github.com/sleighzy/ansible-kafka/workflows/Molecule/badge.svg
+[molecule installation guide]:
+  https://molecule.readthedocs.io/en/stable/installation.html
+[mit license]: https://img.shields.io/badge/License-MIT-blue.svg

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,15 +1,26 @@
 ---
 galaxy_info:
   author: Simon Leigh
-  description: Apache Kafka installation for RHEL / CentOS 6 and 7
+  description: Apache Kafka installation for RHEL/CentOS and Debian/Ubuntu
   license: MIT
   min_ansible_version: 2.x
   platforms:
     - name: EL
       versions:
-      - all
+        - 6
+        - 7
+        - 8
+    - name: Debian
+      versions:
+        - buster
+    - name: Ubuntu
+      versions:
+        - bionic
   galaxy_tags:
+    - clustering
     - kafka
     - messaging
+    - pubsub
+    - streaming
 
 dependencies: []

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -3,4 +3,8 @@
   hosts: all
   roles:
     - sleighzy.zookeeper
-    - ansible-kafka
+
+  tasks:
+    - name: 'Test Kafka role'
+      include_role:
+        name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,12 +4,22 @@ dependency:
   options:
     ignore-certs: True
     ignore-errors: True
-    role-file: requirements.yml
+    role-file: molecule/default/requirements.yml
 driver:
   name: docker
 platforms:
-  - name: instance
-    image: centos:7
+  - name: server-1
+    image: geerlingguy/docker-debian10-ansible:latest
+    docker_networks:
+      - name: kafka
+        ipam_config:
+          - subnet: '172.40.0.0/16'
+    networks:
+      - name: kafka
+        ipv4_address: '172.40.10.1'
+    etc_hosts: "{'server-2': '172.40.10.2', 'server-3': '172.40.10.3'}"
+    pre_build_image: true
+    privileged: True
     tmpfs:
       - /run
       - /tmp
@@ -17,22 +27,71 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     capabilities:
       - SYS_ADMIN
-    command: '/usr/sbin/init'
+    command: /lib/systemd/systemd
     groups:
-      - zookeeper-nodes
       - kafka-nodes
+      - zookeeper-nodes
+  - name: server-2
+    image: centos:7
+    networks:
+      - name: kafka
+        ipv4_address: '172.40.10.2'
+    etc_hosts: "{'server-1': '172.40.10.1', 'server-3': '172.40.10.3'}"
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: '/sbin/init'
+    capabilities:
+      - SYS_ADMIN
+    groups:
+      - kafka-nodes
+      - zookeeper-nodes
+  - name: server-3
+    image: registry.access.redhat.com/ubi8/ubi-init
+    networks:
+      - name: kafka
+        ipv4_address: '172.40.10.3'
+    etc_hosts: "{'server-1': '172.40.10.1', 'server-2': '172.40.10.2'}"
+    privileged: True
+    tmpfs:
+      - /run
+      - /tmp
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    command: '/usr/sbin/init'
+    pre_build_image: true
+    capabilities:
+      - SYS_ADMIN
+    groups:
+      - kafka-nodes
+      - zookeeper-nodes
 provisioner:
   name: ansible
-  lint:
-    name: ansible-lint
-  playbooks:
-    prepare: prepare.yml
-verifier:
-  name: ansible
+  inventory:
+    group_vars:
+      kafka_zookeeper_connect: 'server-1:2181,server-2:2181,server-3:2181/kafka'
+      kafka_bootstrap_servers: 'server-1:9092,server-2:9092,server-3:9092'
+    host_vars:
+      server-1:
+        zookeeper_id: 1
+        kafka_broker_id: 0
+        kafka_listener_hostname: server-1
+      server-2:
+        zookeeper_id: 2
+        kafka_broker_id: 1
+        kafka_listener_hostname: server-2
+      server-3:
+        zookeeper_id: 3
+        kafka_broker_id: 2
+        kafka_listener_hostname: server-3
 lint: |
   set -e
-  yamllint . -c ./.yamllint.yaml
-  ansible-lint . -c ./.ansible-lint
+  yamllint -c ./.yamllint.yaml .
+  ansible-lint -c ./.ansible-lint .
+verifier:
+  name: ansible
 scenario:
   create_sequence:
     - dependency

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,9 +1,29 @@
 ---
 - name: Prepare
   hosts: all
-  gather_facts: false
+  gather_facts: true
+
   pre_tasks:
-    - name: Install Java 8 (OpenJDK)
+    - name: Install Java 8 (OpenJDK) on RedHat/CentOS
       yum:
         name: java-1.8.0-openjdk
         state: installed
+      when: ansible_os_family == "RedHat"
+
+    - name: Install Java 11 (OpenJDK) on Debian
+      apt:
+        name: openjdk-11-jdk
+        state: present
+        update_cache: yes
+      when: ansible_os_family == "Debian"
+
+    # The installation of this package into the Debian container means
+    # that the "ps" command is available for viewing the running process.
+    # Installing this package however also prevents an issue whereby the
+    # ZooKeeper service is constantly restarted by systemd which causes
+    # the Molecule tests to fail as the service is not started correctly.
+    - name: Install ps on Debian
+      apt:
+        name: procps
+        state: present
+      when: ansible_os_family == "Debian"

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -5,7 +5,7 @@
     - ../vars/{{ ansible_os_family }}.yml
     - ../vars/{{ ansible_distribution_release }}.yml
     - ../vars/empty.yml
-  tags: 
+  tags:
     - always
 
 - name: Create kafka group
@@ -64,6 +64,7 @@
     state: directory
     group: '{{ kafka_group }}'
     owner: '{{ kafka_user }}'
+    mode: 0755
   tags:
     - kafka_dirs
 
@@ -73,6 +74,7 @@
     state: directory
     group: '{{ kafka_group }}'
     owner: '{{ kafka_user }}'
+    mode: 0755
   tags:
     - kafka_dirs
 
@@ -80,6 +82,9 @@
   template:
     src: server.properties.j2
     dest: '{{ kafka_dir }}/config/server.properties'
+    group: '{{ kafka_group }}'
+    owner: '{{ kafka_user }}'
+    mode: 0644
   notify:
     - Restart kafka service
   tags:
@@ -89,6 +94,9 @@
   template:
     src: zookeeper.properties.j2
     dest: '{{ kafka_dir }}/config/zookeeper.properties'
+    group: '{{ kafka_group }}'
+    owner: '{{ kafka_user }}'
+    mode: 0644
   tags:
     - kafka_config
 
@@ -96,6 +104,9 @@
   template:
     src: connect-standalone.properties.j2
     dest: '{{ kafka_dir }}/config/connect-standalone.properties'
+    group: '{{ kafka_group }}'
+    owner: '{{ kafka_user }}'
+    mode: 0644
   tags:
     - kafka_config
 
@@ -103,6 +114,9 @@
   template:
     src: connect-distributed.properties.j2
     dest: '{{ kafka_dir }}/config/connect-distributed.properties'
+    group: '{{ kafka_group }}'
+    owner: '{{ kafka_user }}'
+    mode: 0644
   tags:
     - kafka_config
 
@@ -110,6 +124,9 @@
   template:
     src: producer.properties.j2
     dest: '{{ kafka_dir }}/config/producer.properties'
+    group: '{{ kafka_group }}'
+    owner: '{{ kafka_user }}'
+    mode: 0644
   tags:
     - kafka_config
 
@@ -117,6 +134,9 @@
   template:
     src: consumer.properties.j2
     dest: '{{ kafka_dir }}/config/consumer.properties'
+    group: '{{ kafka_group }}'
+    owner: '{{ kafka_user }}'
+    mode: 0644
   tags:
     - kafka_config
 
@@ -174,7 +194,9 @@
   template:
     src: kafka.initd.j2
     dest: /etc/init.d/kafka
-    mode: 0755
+    group: '{{ kafka_group }}'
+    owner: '{{ kafka_user }}'
+    mode: 0644
   notify:
     - Reload initd
     - Restart kafka service
@@ -186,6 +208,9 @@
   template:
     src: kafka.service.j2
     dest: "{{ kafka_unit_path }}"
+    group: '{{ kafka_group }}'
+    owner: '{{ kafka_user }}'
+    mode: 0644
   notify:
     - Restart kafka systemd
   when: ansible_os_family == "RedHat" and ansible_distribution_major_version > '6' or ansible_os_family == "Debian"

--- a/templates/kafka.initd.j2
+++ b/templates/kafka.initd.j2
@@ -7,6 +7,7 @@
 # processname: kafka
 
 # Source function library.
+# shellcheck disable=SC1091
 . /etc/init.d/functions
 
 RETVAL=0
@@ -14,11 +15,12 @@ prog="kafka"
 LOCKFILE=/var/lock/subsys/$prog
 
 # Declare variables for Kafka
+# shellcheck disable=SC1083
 KAFKA_HOME_DIR={{ kafka_dir }}
 
 start() {
         echo -n "Starting $prog: "
-        $KAFKA_HOME_DIR/bin/kafka-start-server.sh $KAFKA_HOME_DIR/config/server.properties
+        "$KAFKA_HOME_DIR/bin/kafka-start-server.sh" "$KAFKA_HOME_DIR/config/server.properties"
         RETVAL=$?
         [ $RETVAL -eq 0 ] && touch $LOCKFILE
         echo
@@ -27,7 +29,8 @@ start() {
 
 stop() {
         echo -n "Shutting down $prog: "
-        $KAFKA_HOME_DIR/bin/kafka-stop-server.sh && success || failure
+        # shellcheck disable=SC2015
+        "$KAFKA_HOME_DIR/bin/kafka-stop-server.sh" && success || failure
         RETVAL=$?
         [ $RETVAL -eq 0 ] && rm -f $LOCKFILE
         echo

--- a/tests/test.yaml
+++ b/tests/test.yaml
@@ -1,89 +1,87 @@
 ---
-
 - hosts: localhost
 
   tasks:
-
-  # Create a Docker network that the containers will connect to. This will enable the
-  # containers to be able to see and access each other.
-  # This requires Ansible 2.2 for this docker_network module.
-  - name: Create Docker network
-    docker_network:
-      name: kafka
-      ipam_config:
+    # Create a Docker network that the containers will connect to. This will enable the
+    # containers to be able to see and access each other.
+    # This requires Ansible 2.2 for this docker_network module.
+    - name: Create Docker network
+      docker_network:
+        name: kafka
+        ipam_config:
           - subnet: '172.25.0.0/16'
 
-  # The centos/systemd image used to create these containers is required so
-  # that systemd is available. This is used for the systemctl commands to
-  # install and run the zookeeper services for this role. The privileged container
-  # and "/sys/fs/cgroup" volume mount is also required for systemd support.
-  # The container needs to be started with the "/usr/lib/systemd/systemd" so that
-  # this service is initialized.
-  - name: Create ZooKeeper Docker containers
-    docker_container:
-      name: '{{ item.1 }}'
-      hostname: '{{ item.1 }}'
-      image: centos/systemd
-      state: started
-      privileged: yes
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
-      networks:
-        - name: kafka
-          ipv4_address: 172.25.10.{{ item.0 + 1 }}
-      purge_networks: yes
-      exposed_ports:
-        - 2181
-        - 2888
-        - 3888
-      etc_hosts:
-        zookeeper-1: 172.25.10.1
-        zookeeper-2: 172.25.10.2
-        zookeeper-3: 172.25.10.3
-        kafka-1: 172.25.20.1
-        kafka-2: 172.25.20.2
-        kafka-3: 172.25.20.3
-      command: /usr/lib/systemd/systemd
-    with_indexed_items: "{{ groups['zookeeper-nodes'] }}"
+    # The centos/systemd image used to create these containers is required so
+    # that systemd is available. This is used for the systemctl commands to
+    # install and run the zookeeper services for this role. The privileged container
+    # and "/sys/fs/cgroup" volume mount is also required for systemd support.
+    # The container needs to be started with the "/usr/lib/systemd/systemd" so that
+    # this service is initialized.
+    - name: Create ZooKeeper Docker containers
+      docker_container:
+        name: '{{ item.1 }}'
+        hostname: '{{ item.1 }}'
+        image: centos/systemd
+        state: started
+        privileged: yes
+        volumes:
+          - /sys/fs/cgroup:/sys/fs/cgroup:ro
+        networks:
+          - name: kafka
+            ipv4_address: 172.25.10.{{ item.0 + 1 }}
+        purge_networks: yes
+        exposed_ports:
+          - 2181
+          - 2888
+          - 3888
+        etc_hosts:
+          zookeeper-1: 172.25.10.1
+          zookeeper-2: 172.25.10.2
+          zookeeper-3: 172.25.10.3
+          kafka-1: 172.25.20.1
+          kafka-2: 172.25.20.2
+          kafka-3: 172.25.20.3
+        command: /usr/lib/systemd/systemd
+      with_indexed_items: "{{ groups['zookeeper-nodes'] }}"
 
-  # The centos/systemd image used to create these containers is required so
-  # that systemd is available. This is used for the systemctl commands to
-  # install and run the kafka services for this role. The privileged container
-  # and "/sys/fs/cgroup" volume mount is also requird for systemd support.
-  # Port 9092 is exposed as the Kafka broker port.
-  # The container needs to be started with the "/usr/lib/systemd/systemd" so that
-  # this service is initialized.
-  - name: Create Kafka Docker containers
-    docker_container:
-      name: '{{ item.1 }}'
-      hostname: '{{ item.1 }}'
-      image: centos/systemd
-      state: started
-      privileged: yes
-      volumes:
-        - /sys/fs/cgroup:/sys/fs/cgroup:ro
-      networks:
-        - name: kafka
-          ipv4_address: 172.25.20.{{ item.0 + 1 }}
-      purge_networks: yes
-      exposed_ports:
-        - 9092
-      etc_hosts:
-        zookeeper-1: 172.25.10.1
-        zookeeper-2: 172.25.10.2
-        zookeeper-3: 172.25.10.3
-        kafka-1: 172.25.20.1
-        kafka-2: 172.25.20.2
-        kafka-3: 172.25.20.3
-      command: /usr/lib/systemd/systemd
-    with_indexed_items: "{{ groups['kafka-nodes'] }}"
+    # The centos/systemd image used to create these containers is required so
+    # that systemd is available. This is used for the systemctl commands to
+    # install and run the kafka services for this role. The privileged container
+    # and "/sys/fs/cgroup" volume mount is also requird for systemd support.
+    # Port 9092 is exposed as the Kafka broker port.
+    # The container needs to be started with the "/usr/lib/systemd/systemd" so that
+    # this service is initialized.
+    - name: Create Kafka Docker containers
+      docker_container:
+        name: '{{ item.1 }}'
+        hostname: '{{ item.1 }}'
+        image: centos/systemd
+        state: started
+        privileged: yes
+        volumes:
+          - /sys/fs/cgroup:/sys/fs/cgroup:ro
+        networks:
+          - name: kafka
+            ipv4_address: 172.25.20.{{ item.0 + 1 }}
+        purge_networks: yes
+        exposed_ports:
+          - 9092
+        etc_hosts:
+          zookeeper-1: 172.25.10.1
+          zookeeper-2: 172.25.10.2
+          zookeeper-3: 172.25.10.3
+          kafka-1: 172.25.20.1
+          kafka-2: 172.25.20.2
+          kafka-3: 172.25.20.3
+        command: /usr/lib/systemd/systemd
+      with_indexed_items: "{{ groups['kafka-nodes'] }}"
 
 - hosts: all
   tasks:
-  - name: Install Java 8 (OpenJDK)
-    yum:
-      name: java-1.8.0-openjdk
-      state: latest
+    - name: Install Java 8 (OpenJDK)
+      yum:
+        name: java-1.8.0-openjdk
+        state: installed
 
 - hosts: zookeeper-nodes
   roles:


### PR DESCRIPTION
The Molecule tests create a ZooKeeper and Kafka cluster consisting of three nodes running
within Docker containers. Each Docker container is a different OS to test the platforms
that this role supports.

Include Kafka role for testing and group and host vars. Group vars contain the global configuration
for ZooKeeper connection strings and the location of the Kafka bootstrap servers.

The inclusion of the Kafka role for testing uses an environment lookup to locate the project
directory of the role to be tested. This is to support being able to locate the role no matter
what the name of the directory it has been checked out to.

Update role metadata to list supported platforms.

Add group and user and file mode when creating directories and templating files.

Github Actions workflows added for Molecule tests and linting codebase:

- the Github super-linter is used for linting files
- the ansible-lint-action is used to lint the Ansible role files
- add status badges to README