### PR TITLE
Upgrade to Apache Kafka 2.8.0

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-lint yamllint docker molecule[docker,lint]
+        run: pip3 install ansible ansible-lint yamllint docker molecule-docker molecule[docker,lint]
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 # General file ignores
 .DS_Store
+.vscode
+super-linter.log
 
-.Python
+# Symlink to current repository to enable Ansible to find the role
+# using its expected full name for Molecule tests
+.cache/
 
 # Python virtual env for Molecule testing
 molecule-venv/
-.vscode

--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ needed.
 ansible-galaxy install sleighzy.zookeeper
 ```
 
+Ansible 2.9.16 or 2.10.4 are the minimum required versions to workaround an
+issue with certain kernels that have broken the `systemd` status check. The
+error message "`Service is in unknown state`" will be output when attempting to
+start the service via the Ansible role and the task will fail. The service will
+start as expected if the `systemctl start` command is run on the physical host.
+See <https://github.com/ansible/ansible/issues/71528> for more information.
+
 ## Role Variables
 
 | Variable                           | Default                               |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status]](https://travis-ci.org/sleighzy/ansible-kafka)
 ![Lint Code Base] ![Ansible Lint] ![Molecule]
 
-Ansible role to install and configure [Apache Kafka] 2.7.0
+Ansible role to install and configure [Apache Kafka] 2.8.0
 
 [Apache Kafka] is a distributed event streaming platform using publish-subscribe
 topics. Applications and streaming components can produce and consume messages
@@ -37,7 +37,7 @@ ansible-galaxy install sleighzy.zookeeper
 | Variable                           | Default                               |
 | ---------------------------------- | ------------------------------------- |
 | kafka_download_base_url            | <http://www-eu.apache.org/dist/kafka> |
-| kafka_version                      | 2.7.0                                 |
+| kafka_version                      | 2.8.0                                 |
 | kafka_scala_version                | 2.13                                  |
 | kafka_root_dir                     | /opt                                  |
 | kafka_dir                          | {{ kafka_root_dir }}/kafka            |

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ install Molecule including the Docker driver.
 ```sh
 $ python3 -m venv molecule-venv
 $ source molecule-venv/bin/activate
-(molecule-venv) $ python3 -m pip install --user "molecule[docker,lint]"
+(molecule-venv) $ python3 -m pip install molecule-docker "molecule[docker,lint]"
 ```
 
 Run playbook and tests. Linting errors need to be corrected before Molecule will

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ elastically scaled with no downtime.
 - RedHat 8
 - Debian 10.x
 - Ubuntu 18.04.x
+- Ubuntu 20.04.x
 
 ## Requirements
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -2,7 +2,7 @@
 # The Apache Kafka version to be downloaded and installed
 # kafka_download_base_url should be set to https://archive.apache.org/dist/kafka/ for older versions than the current
 kafka_download_base_url: http://www-eu.apache.org/dist/kafka
-kafka_version: 2.7.0
+kafka_version: 2.8.0
 kafka_scala_version: 2.13
 
 # The kafka user and group to create files/dirs with and for running the kafka service

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Simon Leigh
   description: Apache Kafka installation for RHEL/CentOS and Debian/Ubuntu
   license: MIT
-  min_ansible_version: 2.x
+  min_ansible_version: 2.10.4
   platforms:
     - name: EL
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
     - name: Ubuntu
       versions:
         - bionic
+        - focal
   galaxy_tags:
     - clustering
     - kafka

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -60,7 +60,7 @@ platforms:
       - /tmp
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: '/usr/sbin/init'
+    command: '/usr/lib/systemd/systemd'
     pre_build_image: true
     capabilities:
       - SYS_ADMIN

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -16,12 +16,12 @@
           - "'kafka' in getent_passwd"
           - "'kafka' in getent_group"
 
-    - name: Register '/opt/kafka_2.13-2.7.0' installation directory status
+    - name: Register '/opt/kafka_2.13-2.8.0' installation directory status
       stat:
-        path: '/opt/kafka_2.13-2.7.0'
+        path: '/opt/kafka_2.13-2.8.0'
       register: install_dir
 
-    - name: Assert that '/opt/kafka_2.13-2.7.0' directory is created
+    - name: Assert that '/opt/kafka_2.13-2.8.0' directory is created
       assert:
         that:
           - install_dir.stat.exists
@@ -39,7 +39,7 @@
         that:
           - kafka_dir.stat.exists
           - kafka_dir.stat.islnk
-          - kafka_dir.stat.lnk_target == '/opt/kafka_2.13-2.7.0'
+          - kafka_dir.stat.lnk_target == '/opt/kafka_2.13-2.8.0'
 
     - name: Register '/etc/kafka' directory status
       stat:


### PR DESCRIPTION
Upgrade to Apache Kafka 2.8.0

Additional changes:

*  Molecule Docker driver breaking change

    A breaking change in Molecule 3.1.1 removed the Docker driver.
    This must be installed separately using the pip molecule-docker
    module for the Molecule tests to run.

*  Ansible versions for breaking change with kernel versions and systemd

    Some kernel versions have made breaking changes to the attributes
    returned in systemd service calls that Ansible uses to determine what
    state the service is in. Ansible 2.9.16 and 2.10.4 are the minimum
    required versions as a workaround was put in place to use different
    commands to retrieve the service status.

*  Add Ubuntu 20.04 LTS to supported platforms