### PR TITLE
Use LOG_DIR environment variable for application logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ See <https://github.com/ansible/ansible/issues/71528> for more information.
 | kafka_group                                    | kafka                                 |
 | kafka_root_dir                                 | /opt                                  |
 | kafka_dir                                      | {{ kafka_root_dir }}/kafka            |
+| kafka_start                                    | yes                                   |
+| kafka_restart                                  | yes                                   |
 | kafka_log_dir                                  | /var/log/kafka                        |
 | kafka_broker_id                                | 0                                     |
 | kafka_java_heap                                | -Xms1G -Xmx1G                         |

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -13,7 +13,7 @@ kafka_group: kafka
 kafka_root_dir: /opt
 kafka_dir: "{{ kafka_root_dir }}/kafka"
 
-# The application log folder (e.g: server.log) 
+# The application log folder (e.g: server.log)
 kafka_log_dir: /var/log/kafka
 
 # Start kafka after installation
@@ -67,7 +67,7 @@ kafka_socket_request_max_bytes: 104857600
 # The socket receive buffer for network requests
 kafka_replica_socket_receive_buffer_bytes: 65536
 
-# A comma seperated list of directories under which to store log files
+# A comma separated list of directories under which to store data log files
 kafka_data_log_dirs: /var/lib/kafka/logs
 
 # The default number of log partitions per topic. More partitions allow greater

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -54,6 +54,20 @@
           - kafka_log_dir.stat.pw_name == 'kafka'
           - kafka_log_dir.stat.gr_name == 'kafka'
 
+    - name: Register '/opt/kafka/logs' symlink directory status
+      stat:
+        path: '/opt/kafka/logs'
+      register: application_logs_symlink
+
+    - name: Assert that '/opt/kafka/logs' symlink is created
+      assert:
+        that:
+          - application_logs_symlink.stat.exists
+          - application_logs_symlink.stat.islnk
+          - application_logs_symlink.stat.lnk_target == '/var/log/kafka'
+          - application_logs_symlink.stat.pw_name == 'kafka'
+          - application_logs_symlink.stat.gr_name == 'kafka'
+
     - name: Register '/etc/kafka' directory status
       stat:
         path: '/etc/kafka'

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -76,16 +76,27 @@
     state: directory
     group: '{{ kafka_group }}'
     owner: '{{ kafka_user }}'
+    mode: 0755
   tags:
     - kafka_dirs
 
-- name: Create symlink to kafka application logs
+- name: Register '{{ kafka_dir }}/logs' directory status
+  stat:
+    path: '{{ kafka_dir }}/logs'
+  register: application_logs_dir
+  tags:
+    - kafka_dirs
+
+- name: Create symlink to application log directory
   file:
     src: '{{ kafka_log_dir }}'
     dest: '{{ kafka_dir }}/logs'
     state: link
     group: '{{ kafka_group }}'
     owner: '{{ kafka_user }}'
+    mode: 0755
+    follow: no
+  when: not application_logs_dir.stat.exists
   tags:
     - kafka_dirs
 

--- a/templates/kafka.service.j2
+++ b/templates/kafka.service.j2
@@ -8,6 +8,7 @@ After=network.target
 Type=simple
 StandardOutput=null
 Environment="KAFKA_HEAP_OPTS={{ kafka_java_heap }}"
+Environment="LOG_DIR={{ kafka_log_dir }}"
 ExecStart={{ kafka_dir }}/bin/kafka-server-start.sh /etc/kafka/server.properties
 ExecStop={{ kafka_dir }}/bin/kafka-server-stop.sh
 User={{ kafka_user }}


### PR DESCRIPTION
The application logs are written to the /var/log/kafka directory and symlinked to the /opt/kafka/logs directory.

The value for the LOG_DIR environment variable for the process specifies where the application logs are written.
By default the /opt/kafka/logs directory is used if the LOG_DIR environment variable is not present.