### PR TITLE
Add quotes to install of molecule test dependencies

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -30,7 +30,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-lint yamllint docker molecule-docker molecule[docker,lint]
+        run: pip3 install ansible ansible-lint yamllint docker molecule-docker "molecule[docker,lint]"
 
       - name: Run Molecule tests.
         run: molecule test

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,6 +5,7 @@ dependency:
     ignore-certs: True
     ignore-errors: True
     role-file: molecule/default/requirements.yml
+    requirements-file: molecule/default/requirements.yml
 driver:
   name: docker
 platforms:

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,2 +1,4 @@
 roles:
   - sleighzy.zookeeper
+collections:
+  - community.docker


### PR DESCRIPTION
Add missing quotes to the pip3 installation of the molecule driver used in the test dependencies.