### PR TITLE
Create user and group as system user/group

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -12,6 +12,7 @@
   group:
     name: '{{ kafka_group }}'
     state: present
+    system: yes
   when: kafka_create_user_group | bool
   tags:
     - kafka_group
@@ -22,6 +23,7 @@
     group: '{{ kafka_group }}'
     state: present
     createhome: no
+    system: yes
   when: kafka_create_user_group | bool
   tags:
     - kafka_user


### PR DESCRIPTION
Setting this only influences new installs where the user and/or group doesn't exist.

I would have liked to also define the users HOME to `kafka_dir` or `/nonexistent` (used by at least Debian for system users where HOME doesn't really make sense), but that would fail when the user all ready exists because he would usually have a running process.