### PR TITLE
Upgrade to super-linter v4 due to breaking issue

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v4
         env:
           DEFAULT_BRANCH: master
           FILTER_REGEX_EXCLUDE: .*(tests/|Dockerfile.j2).*

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ log4j-related available variables.
 | ------------------------------ | -------------------- |
 | ZooKeeper connection           | localhost:2181       |
 | Kafka bootstrap servers        | localhost:9092       |
-| Kafka consumer group Id        | kafka-consumer-group |
-| Kafka broker id                | 0                    |
+| Kafka consumer group ID        | kafka-consumer-group |
+| Kafka broker ID                | 0                    |
 | Number of partitions           | 1                    |
 | Data log file retention period | 168 hours            |
 | Enable auto topic creation     | false                |


### PR DESCRIPTION
super-linter v3 introduced a critical issue '/action/lib/functions/tapLibrary.sh: No such file or directory'.
This is resolved in v4 and won't be released in v3.