### PR TITLE
Use super-linter slim image to reduce build times

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Lint Code Base
-        uses: github/super-linter@v4
+        uses: github/super-linter/slim@v4
         env:
           DEFAULT_BRANCH: master
           FILTER_REGEX_EXCLUDE: .*(tests/|Dockerfile.j2).*


### PR DESCRIPTION
As per the super-linter docs (https://github.com/github/super-linter#slim-image) the slim image is 2gb smaller in size and reduces the amount of time taken for the linting process in the build pipeline.