### PR TITLE
Upgrade to Apache Kafka 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status]](https://travis-ci.org/sleighzy/ansible-kafka)
 ![Lint Code Base] ![Ansible Lint] ![Molecule]
 
-Ansible role to install and configure [Apache Kafka] 2.8.1
+Ansible role to install and configure [Apache Kafka] 3.1.0
 
 [Apache Kafka] is a distributed event streaming platform using publish-subscribe
 topics. Applications and streaming components can produce and consume messages
@@ -24,7 +24,7 @@ elastically scaled with no downtime.
 ## Requirements
 
 - [Apache ZooKeeper]
-- Java 8 / 11
+- Java 8 (deprecated) / 11 / 17
 
 The below Apache ZooKeeper role from Ansible Galaxy can be used if one is
 needed.
@@ -45,7 +45,7 @@ See <https://github.com/ansible/ansible/issues/71528> for more information.
 | Variable                                       | Default                               |
 | ---------------------------------------------- | ------------------------------------- |
 | kafka_download_base_url                        | <http://www-eu.apache.org/dist/kafka> |
-| kafka_version                                  | 2.8.1                                 |
+| kafka_version                                  | 3.1.0                                 |
 | kafka_scala_version                            | 2.13                                  |
 | kafka_create_user_group                        | true                                  |
 | kafka_user                                     | kafka                                 |

--- a/defaults/main/001-kafka.yml
+++ b/defaults/main/001-kafka.yml
@@ -2,7 +2,7 @@
 # The Apache Kafka version to be downloaded and installed
 # kafka_download_base_url should be set to https://archive.apache.org/dist/kafka/ for older versions than the current
 kafka_download_base_url: http://www-eu.apache.org/dist/kafka
-kafka_version: 2.8.1
+kafka_version: 3.1.0
 kafka_scala_version: 2.13
 
 # The kafka user and group to create files/dirs with and for running the kafka service

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -16,12 +16,12 @@
           - "'kafka' in getent_passwd"
           - "'kafka' in getent_group"
 
-    - name: Register '/opt/kafka_2.13-2.8.1' installation directory status
+    - name: Register '/opt/kafka_2.13-3.1.0' installation directory status
       stat:
-        path: '/opt/kafka_2.13-2.8.1'
+        path: '/opt/kafka_2.13-3.1.0'
       register: install_dir
 
-    - name: Assert that '/opt/kafka_2.13-2.8.1' directory is created
+    - name: Assert that '/opt/kafka_2.13-3.1.0' directory is created
       assert:
         that:
           - install_dir.stat.exists
@@ -39,7 +39,7 @@
         that:
           - kafka_dir.stat.exists
           - kafka_dir.stat.islnk
-          - kafka_dir.stat.lnk_target == '/opt/kafka_2.13-2.8.1'
+          - kafka_dir.stat.lnk_target == '/opt/kafka_2.13-3.1.0'
 
     - name: Register '/var/log/kafka' directory status
       stat:


### PR DESCRIPTION
Upgrade to Apache Kafka 3.1.0

This Ansible role does not explicitly support upgrades from previous versions. Refer to https://kafka.apache.org/documentation.html#upgrade when upgrading for instructions on configuration updates needed during this process.