### PR TITLE
Fixed create Kafka data log dirs

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -64,11 +64,12 @@
 
 - name: Create directory for kafka data log files
   file:
-    path: '{{ kafka_data_log_dirs }}'
+    path: '{{ item }}'
     state: directory
     group: '{{ kafka_group }}'
     owner: '{{ kafka_user }}'
     mode: 0755
+  with_items: "{{ kafka_data_log_dirs.split(',') }}"
   tags:
     - kafka_dirs
 


### PR DESCRIPTION
The Kafka data log directory has been modified to be created by separating them with commas when there are multiple .