### PR TITLE
Add workflow_dispatch to GitHub action

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -10,6 +10,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch:
 
 defaults:
   run:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Apache Kafka
 
 [![Build Status]](https://travis-ci.org/sleighzy/ansible-kafka)
-![Lint Code Base] ![Ansible Lint] ![Molecule]
+![Lint Code Base] ![Molecule]
 
 Ansible role to install and configure [Apache Kafka] 3.1.0
 
@@ -198,8 +198,6 @@ molecule destroy
 
 [![MIT license]](https://lbesson.mit-license.org/)
 
-[ansible lint]:
-  https://github.com/sleighzy/ansible-kafka/workflows/Ansible%20Lint/badge.svg
 [ansible-lint]: https://docs.ansible.com/ansible-lint/
 [apache kafka]: http://kafka.apache.org/
 [apache zookeeper]: https://zookeeper.apache.org/


### PR DESCRIPTION
Added the `workflow_dispatch` to the GitHub actions so that the workflow can be manually triggered.

https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onworkflow_dispatchinputs