### PR TITLE
Feature/adding kafka_config_params feature

### DIFF
--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-compat==0.5.0 ansible-lint yamllint docker molecule-docker "molecule[docker,lint]"
+        run: pip3 install ansible ansible-lint yamllint docker molecule-docker "molecule[docker,lint]"
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ super-linter.log
 
 # Python virtual env for Molecule testing
 molecule-venv/
+
+# IntelliJ IDEA project files
+*.iml

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ See <https://github.com/ansible/ansible/issues/71528> for more information.
 
 ## Role Variables
 
-| Variable                                       | Default                          |
-| ---------------------------------------------- | -------------------------------- |
+| Variable                                       | Default                          | Comments                                                         |
+|------------------------------------------------|----------------------------------|------------------------------------------------------------------|
 | kafka_download_base_url                        | <https://dlcdn.apache.org/kafka> |
 | kafka_download_validate_certs                  | yes                              |
 | kafka_version                                  | 3.2.0                            |
@@ -85,6 +85,7 @@ See <https://github.com/ansible/ansible/issues/71528> for more information.
 | kafka_zookeeper_connection_timeout             | 6000                             |
 | kafka_bootstrap_servers                        | localhost:9092                   |
 | kafka_consumer_group_id                        | kafka-consumer-group             |
+| kafka_config_params                            |                                  | General dictionary that will be templated into server.properties |
 
 See [log4j.yml](./defaults/main/002-log4j.yml) for detailed  
 log4j-related available variables.

--- a/templates/server.properties.j2
+++ b/templates/server.properties.j2
@@ -193,3 +193,7 @@ ssl.keystore.password={{ kafka_ssl.keystore_password }}
 ssl.key.password={{ kafka_ssl.key_password }}
 ssl.client.auth={{ kafka_ssl.client_auth }}
 {% endif %}
+
+{% for key, value in (kafka_config_params | default({})).items() %}
+{{key}}={{value}}
+{% endfor %}


### PR DESCRIPTION
Similar to https://github.com/sleighzy/ansible-zookeeper/issues/39 where you can use the parameter `kafka_config_params` to add any parameter to the `server.properties` file for kafka to use