### PR TITLE
Update GitHub actions for Node 16

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,5 +2,8 @@ exclude_paths:
   - ./molecule-venv/
   - ./tests/roles/
 
+mock_roles:
+  - role: sleighzy.zookeeper
+
 skip_list:
-  - '106'  # Role name does not match ``^[a-z][a-z0-9_]+$`` pattern
+  - '106' # Role name does not match ``^[a-z][a-z0-9_]+$`` pattern

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,7 +3,7 @@ exclude_paths:
   - ./tests/roles/
 
 mock_roles:
-  - role: sleighzy.zookeeper
+  - sleighzy.zookeeper
 
 skip_list:
   - '106' # Role name does not match ``^[a-z][a-z0-9_]+$`` pattern

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -31,3 +31,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           LINTER_RULES_PATH: /
           MARKDOWN_CONFIG_FILE: .markdownlint.json
+
+      - name: Ansible Lint
+        uses: ansible/ansible-lint@v6

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -31,7 +31,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-compat==0.5.0 docker "molecule-plugins[docker]"
+        run: pip3 install ansible docker "molecule-plugins[docker]"
 
       - name: Run Molecule tests.
         run: molecule test

--- a/.github/workflows/molecule.yaml
+++ b/.github/workflows/molecule.yaml
@@ -21,17 +21,17 @@ jobs:
 
     steps:
       - name: Check out the codebase.
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: 'sleighzy.kafka'
 
       - name: Set up Python 3.
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible ansible-compat==0.5.0 ansible-lint yamllint docker molecule-docker "molecule[docker,lint]"
+        run: pip3 install ansible ansible-compat==0.5.0 docker "molecule-plugins[docker]"
 
       - name: Run Molecule tests.
         run: molecule test

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Linting should be done using [ansible-lint].
 
 ```sh
 pip3 install ansible-lint --user
+
+ansible-lint -c ./.ansible-lint .
 ```
 
 ## Testing
@@ -212,7 +214,7 @@ molecule destroy
 
 ## License
 
-[![MIT license]](https://lbesson.mit-license.org/)
+![MIT license]
 
 [ansible-lint]: https://docs.ansible.com/ansible-lint/
 [ansible molecule]: https://molecule.readthedocs.io/

--- a/handlers/main.yaml
+++ b/handlers/main.yaml
@@ -1,15 +1,16 @@
 ---
 - name: Reload initd
-  command: initctl reload-configuration
+  ansible.builtin.command: initctl reload-configuration
+  changed_when: false
 
 - name: Restart kafka service
-  service:
+  ansible.builtin.service:
     name: kafka
     state: restarted
   when: kafka_restart
 
 - name: Restart kafka systemd
-  systemd:
+  ansible.builtin.systemd:
     name: kafka
     state: restarted
     daemon_reload: yes

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,9 +9,9 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - 6
-        - 7
-        - 8
+        - '6'
+        - '7'
+        - '8'
     - name: Debian
       versions:
         - buster

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,5 +6,5 @@
 
   tasks:
     - name: 'Test Kafka role'
-      include_role:
+      ansible.builtin.include_role:
         name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -88,10 +88,6 @@ provisioner:
         zookeeper_id: 3
         kafka_broker_id: 2
         kafka_listener_hostname: server-3
-lint: |
-  set -e
-  yamllint -c ./.yamllint.yaml .
-  ansible-lint -c ./.ansible-lint
 verifier:
   name: ansible
 scenario:
@@ -114,7 +110,6 @@ scenario:
     - prepare
     - converge
   test_sequence:
-    - lint
     - destroy
     - dependency
     - syntax

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -20,12 +20,13 @@ platforms:
         ipv4_address: '172.40.10.1'
     etc_hosts: "{'server-2': '172.40.10.2', 'server-3': '172.40.10.3'}"
     pre_build_image: true
-    privileged: True
+    privileged: true
     tmpfs:
       - /run
       - /tmp
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     capabilities:
       - SYS_ADMIN
     command: /lib/systemd/systemd
@@ -33,7 +34,7 @@ platforms:
       - kafka-nodes
       - zookeeper-nodes
   - name: server-2
-    image: centos:7
+    image: rockylinux:8
     networks:
       - name: kafka
         ipv4_address: '172.40.10.2'
@@ -42,8 +43,10 @@ platforms:
       - /run
       - /tmp
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    command: '/sbin/init'
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    command: '/usr/lib/systemd/systemd'
+    pre_build_image: true
     capabilities:
       - SYS_ADMIN
     groups:
@@ -55,12 +58,13 @@ platforms:
       - name: kafka
         ipv4_address: '172.40.10.3'
     etc_hosts: "{'server-1': '172.40.10.1', 'server-2': '172.40.10.2'}"
-    privileged: True
+    privileged: true
     tmpfs:
       - /run
       - /tmp
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     command: '/usr/lib/systemd/systemd'
     pre_build_image: true
     capabilities:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -5,13 +5,13 @@
 
   pre_tasks:
     - name: Install Java 8 (OpenJDK) on RedHat/CentOS
-      yum:
+      ansible.builtin.yum:
         name: java-1.8.0-openjdk
         state: installed
       when: ansible_os_family == "RedHat"
 
     - name: Install Java 11 (OpenJDK) on Debian
-      apt:
+      ansible.builtin.apt:
         name: openjdk-11-jdk
         state: present
         update_cache: yes
@@ -23,7 +23,7 @@
     # ZooKeeper service is constantly restarted by systemd which causes
     # the Molecule tests to fail as the service is not started correctly.
     - name: Install ps on Debian
-      apt:
+      ansible.builtin.apt:
         name: procps
         state: present
       when: ansible_os_family == "Debian"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -17,7 +17,7 @@
         update_cache: yes
       when: ansible_os_family == "Debian"
 
-    # The installation of this package into the Debian container means
+    # The installation of this package into the container means
     # that the "ps" command is available for viewing the running process.
     # Installing this package however also prevents an issue whereby the
     # ZooKeeper service is constantly restarted by systemd which causes
@@ -27,3 +27,10 @@
         name: procps
         state: present
       when: ansible_os_family == "Debian"
+
+    - name: Install ps on Rocky Linux
+      ansible.builtin.yum:
+        name: procps
+        state: present
+        use_backend: dnf
+      when: ansible_distribution == "Rocky" and ansible_distribution_major_version == "8"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -3,26 +3,26 @@
 
   tasks:
     - name: Get users
-      getent:
+      ansible.builtin.getent:
         database: passwd
 
     - name: Get groups
-      getent:
+      ansible.builtin.getent:
         database: group
 
-    - name: Assert that user and group 'kafka' exists
-      assert:
+    - name: ansible.builtin.assert that user and group 'kafka' exists
+      ansible.builtin.assert:
         that:
           - "'kafka' in getent_passwd"
           - "'kafka' in getent_group"
 
     - name: Register '/opt/kafka_2.13-3.5.1' installation directory status
-      stat:
+      ansible.builtin.stat:
         path: '/opt/kafka_2.13-3.5.1'
       register: install_dir
 
-    - name: Assert that '/opt/kafka_2.13-3.5.1' directory is created
-      assert:
+    - name: ansible.builtin.assert that '/opt/kafka_2.13-3.5.1' directory is created
+      ansible.builtin.assert:
         that:
           - install_dir.stat.exists
           - install_dir.stat.isdir
@@ -30,12 +30,12 @@
           - install_dir.stat.gr_name == 'kafka'
 
     - name: Register '/opt/kafka' symlink directory status
-      stat:
+      ansible.builtin.stat:
         path: '/opt/kafka'
       register: kafka_dir
 
-    - name: Assert that '/opt/kafka' symlink is created
-      assert:
+    - name: ansible.builtin.assert that '/opt/kafka' symlink is created
+      ansible.builtin.assert:
         that:
           - kafka_dir.stat.exists
           - kafka_dir.stat.islnk
@@ -46,8 +46,8 @@
         path: '/var/log/kafka'
       register: kafka_log_dir
 
-    - name: Assert that '/var/log/kafka' directory is created
-      assert:
+    - name: ansible.builtin.assert that '/var/log/kafka' directory is created
+      ansible.builtin.assert:
         that:
           - kafka_log_dir.stat.exists
           - kafka_log_dir.stat.isdir
@@ -55,12 +55,12 @@
           - kafka_log_dir.stat.gr_name == 'kafka'
 
     - name: Register '/opt/kafka/logs' symlink directory status
-      stat:
+      ansible.builtin.stat:
         path: '/opt/kafka/logs'
       register: application_logs_symlink
 
-    - name: Assert that '/opt/kafka/logs' symlink is created
-      assert:
+    - name: ansible.builtin.assert that '/opt/kafka/logs' symlink is created
+      ansible.builtin.assert:
         that:
           - application_logs_symlink.stat.exists
           - application_logs_symlink.stat.islnk
@@ -69,12 +69,12 @@
           - application_logs_symlink.stat.gr_name == 'kafka'
 
     - name: Register '/etc/kafka' directory status
-      stat:
+      ansible.builtin.stat:
         path: '/etc/kafka'
       register: config_dir
 
-    - name: Assert that '/etc/kafka' directory is created
-      assert:
+    - name: ansible.builtin.assert that '/etc/kafka' directory is created
+      ansible.builtin.assert:
         that:
           - config_dir.stat.exists
           - config_dir.stat.isdir
@@ -82,10 +82,10 @@
           - config_dir.stat.gr_name == 'kafka'
 
     - name: Populate service facts
-      service_facts:
+      ansible.builtin.service_facts:
 
-    - name: Assert that Kafka service is installed, running, and enabled
-      assert:
+    - name: ansible.builtin.assert that Kafka service is installed, running, and enabled
+      ansible.builtin.assert:
         that:
           - "'kafka.service' in ansible_facts.services"
           - ansible_facts.services['kafka.service'].state == 'running'

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -10,7 +10,7 @@
       ansible.builtin.getent:
         database: group
 
-    - name: ansible.builtin.assert that user and group 'kafka' exists
+    - name: Assert that user and group 'kafka' exists
       ansible.builtin.assert:
         that:
           - "'kafka' in getent_passwd"
@@ -21,7 +21,7 @@
         path: '/opt/kafka_2.13-3.5.1'
       register: install_dir
 
-    - name: ansible.builtin.assert that '/opt/kafka_2.13-3.5.1' directory is created
+    - name: Assert that '/opt/kafka_2.13-3.5.1' directory is created
       ansible.builtin.assert:
         that:
           - install_dir.stat.exists
@@ -34,7 +34,7 @@
         path: '/opt/kafka'
       register: kafka_dir
 
-    - name: ansible.builtin.assert that '/opt/kafka' symlink is created
+    - name: Assert that '/opt/kafka' symlink is created
       ansible.builtin.assert:
         that:
           - kafka_dir.stat.exists
@@ -46,7 +46,7 @@
         path: '/var/log/kafka'
       register: kafka_log_dir
 
-    - name: ansible.builtin.assert that '/var/log/kafka' directory is created
+    - name: Assert that '/var/log/kafka' directory is created
       ansible.builtin.assert:
         that:
           - kafka_log_dir.stat.exists
@@ -59,7 +59,7 @@
         path: '/opt/kafka/logs'
       register: application_logs_symlink
 
-    - name: ansible.builtin.assert that '/opt/kafka/logs' symlink is created
+    - name: Assert that '/opt/kafka/logs' symlink is created
       ansible.builtin.assert:
         that:
           - application_logs_symlink.stat.exists
@@ -73,7 +73,7 @@
         path: '/etc/kafka'
       register: config_dir
 
-    - name: ansible.builtin.assert that '/etc/kafka' directory is created
+    - name: Assert that '/etc/kafka' directory is created
       ansible.builtin.assert:
         that:
           - config_dir.stat.exists
@@ -84,7 +84,7 @@
     - name: Populate service facts
       ansible.builtin.service_facts:
 
-    - name: ansible.builtin.assert that Kafka service is installed, running, and enabled
+    - name: Assert that Kafka service is installed, running, and enabled
       ansible.builtin.assert:
         that:
           - "'kafka.service' in ansible_facts.services"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -42,7 +42,7 @@
           - kafka_dir.stat.lnk_target == '/opt/kafka_2.13-3.5.1'
 
     - name: Register '/var/log/kafka' directory status
-      stat:
+      ansible.builtin.stat:
         path: '/var/log/kafka'
       register: kafka_log_dir
 

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Load OS-specific variables
-  include_vars: '{{ item }}'
+  ansible.builtin.include_vars: '{{ item }}'
   with_first_found:
     - ../vars/{{ ansible_os_family }}.yml
     - ../vars/{{ ansible_distribution_release }}.yml
@@ -85,7 +85,7 @@
   tags:
     - kafka_dirs
 
-- name: Register directory status for '{{ kafka_dir}}/logs'
+- name: Register directory status for {{ kafka_dir }}/logs
   ansible.builtin.stat:
     path: '{{ kafka_dir }}/logs'
   register: application_logs_dir

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -9,7 +9,7 @@
     - always
 
 - name: Create kafka group
-  group:
+  ansible.builtin.group:
     name: '{{ kafka_group }}'
     state: present
     system: yes
@@ -18,7 +18,7 @@
     - kafka_group
 
 - name: Create kafka user
-  user:
+  ansible.builtin.user:
     name: '{{ kafka_user }}'
     group: '{{ kafka_group }}'
     state: present
@@ -29,21 +29,22 @@
     - kafka_user
 
 - name: Check if Kafka has already been downloaded and unpacked
-  stat:
+  ansible.builtin.stat:
     path: '{{ kafka_dir }}_{{ kafka_scala_version }}-{{ kafka_version }}'
   register: dir
 
 - name: Download Apache Kafka
-  get_url:
+  ansible.builtin.get_url:
     url: '{{ kafka_download_base_url }}/{{ kafka_version }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz'
     dest: /tmp
     validate_certs: '{{ kafka_download_validate_certs }}'
+    mode: 0644
   when: not dir.stat.exists
   tags:
     - kafka_download
 
 - name: Unpack Apache Kafka
-  unarchive:
+  ansible.builtin.unarchive:
     src: /tmp/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz
     dest: '{{ kafka_root_dir }}'
     copy: no
@@ -54,7 +55,7 @@
     - kafka_unpack
 
 - name: Create symlink to kafka installation directory
-  file:
+  ansible.builtin.file:
     src: '{{ kafka_root_dir }}/kafka_{{ kafka_scala_version }}-{{ kafka_version }}'
     dest: '{{ kafka_dir }}'
     state: link
@@ -64,7 +65,7 @@
     - kafka_dirs
 
 - name: Create directory for kafka data log files
-  file:
+  ansible.builtin.file:
     path: '{{ item }}'
     state: directory
     group: '{{ kafka_group }}'
@@ -75,7 +76,7 @@
     - kafka_dirs
 
 - name: Create directory for kafka application logs
-  file:
+  ansible.builtin.file:
     path: '{{ kafka_log_dir }}'
     state: directory
     group: '{{ kafka_group }}'
@@ -84,15 +85,15 @@
   tags:
     - kafka_dirs
 
-- name: Register '{{ kafka_dir }}/logs' directory status
-  stat:
+- name: Register directory status for '{{ kafka_dir}}/logs'
+  ansible.builtin.stat:
     path: '{{ kafka_dir }}/logs'
   register: application_logs_dir
   tags:
     - kafka_dirs
 
 - name: Create symlink to application log directory
-  file:
+  ansible.builtin.file:
     src: '{{ kafka_log_dir }}'
     dest: '{{ kafka_dir }}/logs'
     state: link
@@ -105,7 +106,7 @@
     - kafka_dirs
 
 - name: Create directory for symlink to kafka configuration files
-  file:
+  ansible.builtin.file:
     path: /etc/kafka
     state: directory
     group: '{{ kafka_group }}'
@@ -115,7 +116,7 @@
     - kafka_dirs
 
 - name: Template configuration file to server.properties
-  template:
+  ansible.builtin.template:
     src: server.properties.j2
     dest: '{{ kafka_dir }}/config/server.properties'
     group: '{{ kafka_group }}'
@@ -127,7 +128,7 @@
     - kafka_config
 
 - name: Template configuration file to zookeeper.properties
-  template:
+  ansible.builtin.template:
     src: zookeeper.properties.j2
     dest: '{{ kafka_dir }}/config/zookeeper.properties'
     group: '{{ kafka_group }}'
@@ -137,7 +138,7 @@
     - kafka_config
 
 - name: Template configuration file to connect-standalone.properties
-  template:
+  ansible.builtin.template:
     src: connect-standalone.properties.j2
     dest: '{{ kafka_dir }}/config/connect-standalone.properties'
     group: '{{ kafka_group }}'
@@ -147,7 +148,7 @@
     - kafka_config
 
 - name: Template configuration file to connect-distributed.properties
-  template:
+  ansible.builtin.template:
     src: connect-distributed.properties.j2
     dest: '{{ kafka_dir }}/config/connect-distributed.properties'
     group: '{{ kafka_group }}'
@@ -157,7 +158,7 @@
     - kafka_config
 
 - name: Template configuration file to producer.properties
-  template:
+  ansible.builtin.template:
     src: producer.properties.j2
     dest: '{{ kafka_dir }}/config/producer.properties'
     group: '{{ kafka_group }}'
@@ -167,7 +168,7 @@
     - kafka_config
 
 - name: Template configuration file to consumer.properties
-  template:
+  ansible.builtin.template:
     src: consumer.properties.j2
     dest: '{{ kafka_dir }}/config/consumer.properties'
     group: '{{ kafka_group }}'
@@ -177,7 +178,7 @@
     - kafka_config
 
 - name: Template configuration file to log4j.properties
-  template:
+  ansible.builtin.template:
     src: log4j.properties.j2
     dest: '{{ kafka_dir }}/config/log4j.properties'
     group: '{{ kafka_group }}'
@@ -187,7 +188,7 @@
     - kafka_config
 
 - name: Create symlink to kafka server properties file
-  file:
+  ansible.builtin.file:
     src: '{{ kafka_dir }}/config/server.properties'
     dest: /etc/kafka/server.properties
     state: link
@@ -197,7 +198,7 @@
     - kafka_config
 
 - name: Create symlink to kafka connect standalone properties file
-  file:
+  ansible.builtin.file:
     src: '{{ kafka_dir }}/config/connect-standalone.properties'
     dest: /etc/kafka/connect-standalone.properties
     state: link
@@ -207,7 +208,7 @@
     - kafka_config
 
 - name: Create symlink to kafka connect distributed properties file
-  file:
+  ansible.builtin.file:
     src: '{{ kafka_dir }}/config/connect-distributed.properties'
     dest: /etc/kafka/connect-distributed.properties
     state: link
@@ -217,7 +218,7 @@
     - kafka_config
 
 - name: Create symlink to kafka producer properties file
-  file:
+  ansible.builtin.file:
     src: '{{ kafka_dir }}/config/producer.properties'
     dest: /etc/kafka/producer.properties
     state: link
@@ -227,7 +228,7 @@
     - kafka_config
 
 - name: Create symlink to kafka consumer properties file
-  file:
+  ansible.builtin.file:
     src: '{{ kafka_dir }}/config/consumer.properties'
     dest: /etc/kafka/consumer.properties
     state: link
@@ -237,7 +238,7 @@
     - kafka_config
 
 - name: Create symlink to kafka log4j properties file
-  file:
+  ansible.builtin.file:
     src: '{{ kafka_dir }}/config/log4j.properties'
     dest: /etc/kafka/log4j.properties
     state: link
@@ -247,7 +248,7 @@
     - kafka_config
 
 - name: Template Kafka init.d service file
-  template:
+  ansible.builtin.template:
     src: kafka.initd.j2
     dest: /etc/init.d/kafka
     group: '{{ kafka_group }}'
@@ -261,7 +262,7 @@
     - kafka_service
 
 - name: Template kafka systemd service
-  template:
+  ansible.builtin.template:
     src: kafka.service.j2
     dest: '{{ kafka_unit_path }}'
     group: '{{ kafka_group }}'
@@ -274,7 +275,7 @@
     - kafka_service
 
 - name: Install and start the kafka service
-  service:
+  ansible.builtin.service:
     name: kafka
     state: started
     enabled: yes
@@ -283,7 +284,7 @@
     - kafka_service
 
 - name: Delete the kafka archive file
-  file:
+  ansible.builtin.file:
     path: /tmp/kafka_{{ kafka_scala_version }}-{{ kafka_version }}.tgz
     state: absent
   tags:

--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -85,7 +85,7 @@
   tags:
     - kafka_dirs
 
-- name: Register directory status for {{ kafka_dir }}/logs
+- name: Register directory status for application log files
   ansible.builtin.stat:
     path: '{{ kafka_dir }}/logs'
   register: application_logs_dir


### PR DESCRIPTION
Upgrades for GitHub actions for CI and fixes for linting and Molecule tests

* Upgrade GitHub actions to `actions/checkout@v4` and `actions/setup-python@v4` due to Node 12 deprecation.
* Add support for Docker cGroups v2 to the containers used for testing
* Install `ps` command into test Docker containers to detect that Kafka is running
* Use FQDN for role task names
* Additional fixes for linting errors

Upgrade GitHub actions to `actions/checkout@v4` and `actions/setup-python@v4` due to Node 12 deprecation:

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```

Migrate to molecule-plugins for installing the docker plugin as these have moved in Molecule 5.

Add support for Docker cGroups v2 to the containers used for testing, note that in addition to `cgroupns_mode` the `rw` is flag needed which was previously `ro`

```yaml
volumes:
      - /sys/fs/cgroup:/sys/fs/cgroup:rw
cgroupns_mode: host
```

Use the ansible-lint GitHub action as the lint plugin is not present as part of the Molecule tests and linting can be performed separately.