### PR TITLE
Fix Ansible Molecule unit tests

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -34,7 +34,7 @@ platforms:
       - kafka-nodes
       - zookeeper-nodes
   - name: server-2
-    image: rockylinux:8
+    image: redhat/ubi9:latest
     networks:
       - name: kafka
         ipv4_address: '172.40.10.2'
@@ -53,7 +53,7 @@ platforms:
       - kafka-nodes
       - zookeeper-nodes
   - name: server-3
-    image: registry.access.redhat.com/ubi8/ubi-init
+    image: redhat/ubi9:latest
     networks:
       - name: kafka
         ipv4_address: '172.40.10.3'

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -28,9 +28,8 @@
         state: present
       when: ansible_os_family == "Debian"
 
-    - name: Install ps on Rocky Linux
+    - name: Install ps on RedHat/CentOS
       ansible.builtin.yum:
         name: procps
         state: present
-        use_backend: dnf
-      when: ansible_distribution == "Rocky" and ansible_distribution_major_version == "8"
+      when: ansible_os_family == "RedHat"


### PR DESCRIPTION
Remove Rocky Linux and use RedHat 9 due to breaking Ansible core and Python changes

The ansible-core 2.17 release has dropped support for Python 3.6, which is the default in Rocky Linux (as it is an EL8 platform).
This leads to the "future feature annotations is not defined" error when gathering facts or installing packages.
Installing Python 3.9 also does not work as the issue lies in /usr/libexec/platform-python which is version 3.6,
and is the "system" python which is used for installing modules using dnf or yum.

To resolve this issue the testing containers have been updated to use RedHat 9.