### PR TITLE
Fix version comparison

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -257,7 +257,7 @@
   notify:
     - Reload initd
     - Restart kafka service
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version == '6'
+  when: ansible_os_family == "RedHat" and (ansible_distribution_major_version | int) == 6
   tags:
     - kafka_service
 
@@ -270,7 +270,7 @@
     mode: 0644
   notify:
     - Restart kafka systemd
-  when: ansible_os_family == "RedHat" and ansible_distribution_major_version > '6' or ansible_os_family == "Debian"
+  when: ansible_os_family == "RedHat" and (ansible_distribution_major_version | int) > 6 or ansible_os_family == "Debian"
   tags:
     - kafka_service
 


### PR DESCRIPTION
Comparing OS versions as strings worked perfectly fine for lower versions. Now when RHEL 10 is released, it breaks condition and creation of systemd service.